### PR TITLE
[AV2-311] 'Submitted by' displayed before submission

### DIFF
--- a/src/app/assessment/assessment.component.html
+++ b/src/app/assessment/assessment.component.html
@@ -16,7 +16,7 @@
   <p [class]="assessment.isOverdue ? 'due-date assessment over' : 'due-date assessment'" *ngIf="doAssessment" text-center>
     {{ this.sharedService.dueDateFormatter(assessment.dueDate) }}
   </p>
-  <div class="review-submitter" *ngIf="!doAssessment" text-left>
+  <div *ngIf="!doAssessment && submission.submitterName && !submission.isLocked" class="review-submitter" text-left>
     <p class="title">
       Submitted by {{ submission.submitterName }}
     </p>

--- a/src/app/services/utils.service.ts
+++ b/src/app/services/utils.service.ts
@@ -199,6 +199,8 @@ export class UtilsService {
   }
 
   timeComparer(timeString: string, comparedString?: string, compareDate?: boolean) {
+    // add "T" between date and time to works on Safari
+    timeString = timeString.replace(' ', 'T');
     const time = new Date(timeString + 'Z');
     let compared = new Date();
     if (comparedString) {

--- a/src/app/shared/notification/lock-team-assessment-pop-up/lock-team-assessment-pop-up.component.scss
+++ b/src/app/shared/notification/lock-team-assessment-pop-up/lock-team-assessment-pop-up.component.scss
@@ -28,7 +28,7 @@
   }
 
   .div-after-img {
-    margin: 0 15px 0;
+    margin: 0 15px 15px;
 
     .description {
       text-align: -webkit-center;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -161,13 +161,11 @@ body {
 
 .lock-assessment-popup {
   .modal-wrapper {
-    --height: 40%;
-    --width: 70%;
+    --height: 260px;
+    --width: 260px;
     --background: transparent;
     --box-shadow: none;
     --border-radius: 12px;
-    max-height: 266px;
-    min-height: 266px;
     .inner-scroll, .scroll-y, .overscroll {
       --overflow: hidden;
     }


### PR DESCRIPTION
4 issue in this story.
1. Before submitting anything, the submission page shows blank 'Submitted by'.
2. In team assessment when assessment lock by another user it shows ‘submitted by’.
3. fix button alignment of readonly popup.
4. assessment due dates shows as `overdue` in chrome and `due` in safari.

Jira Story - https://intersective.atlassian.net/browse/AV2-311