### PR TITLE
[AV2-601] WCAG color requirements

### DIFF
--- a/src/theme/pfas/_ionic-components.scss
+++ b/src/theme/pfas/_ionic-components.scss
@@ -7,17 +7,20 @@ ion-header ion-toolbar ion-title {
 ion-textarea, ion-input, input, textarea {
   @extend .subtitle-1;
   --placeholder-color: var(--practera-40-Percent-gray);
+  --placeholder-opacity: 1;
   &::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: var(--practera-40-Percent-gray) !important;
-    opacity: 1; /* Firefox */
+    opacity: 1 !important; /* Firefox */
   }
     
   &:-ms-input-placeholder { /* Internet Explorer 10-11 */
     color: var(--practera-40-Percent-gray) !important;
+    opacity: 1 !important;
   }
     
   &::-ms-input-placeholder { /* Microsoft Edge */
     color: var(--practera-40-Percent-gray) !important;
+    opacity: 1 !important;
   }
   @extend .black;
 }


### PR DESCRIPTION
Jira - https://intersective.atlassian.net/browse/AV2-601
In this PR,
fixed opacity issue in text field placeholders.

In some places there is an extra 0.5 opacity added to placeholder elements, so to keep our color in placeholder need to keep opacity as 1.