### PR TITLE
[AV2-705] event start and end time should not display 0:00pm

### DIFF
--- a/src/app/assessment/assessment.component.ts
+++ b/src/app/assessment/assessment.component.ts
@@ -700,7 +700,7 @@ export class AssessmentComponent extends RouterEnter {
   }
 
   private _getCurrentTime() {
-    return new Intl.DateTimeFormat('en-GB', {
+    return new Intl.DateTimeFormat('en-US', {
       hour12: true,
       hour: 'numeric',
       minute: 'numeric'

--- a/src/app/overview/home/home.service.spec.ts
+++ b/src/app/overview/home/home.service.spec.ts
@@ -149,7 +149,7 @@ describe('HomeService', () => {
         {
           type: 'assessment_submission_reminder',
           name: requestResponse.data[5].meta.assessment_name,
-          description: `Overdue 3 Feb 2019 ${moment(new Date(requestResponse.data[5].meta.due_date + ' GMT+0000')).format('h:mm a')}`,
+          description: `Overdue 3 Feb 2019 ${moment(new Date(requestResponse.data[5].meta.due_date + ' GMT+0000')).format('h:mm A')}`,
           time: '2 Feb',
           meta: requestResponse.data[5].meta
         }

--- a/src/app/overview/home/home.service.spec.ts
+++ b/src/app/overview/home/home.service.spec.ts
@@ -437,7 +437,7 @@ describe('HomeService', () => {
       const expected = {
         type: 'assessment_submission_reminder',
         name: event.meta.AssessmentSubmissionReminder.assessment_name,
-        description: 'Overdue 2 Feb 2019 ' + new Intl.DateTimeFormat('en-GB', {
+        description: 'Overdue 2 Feb 2019 ' + new Intl.DateTimeFormat('en-US', {
             hour12: true,
             hour: 'numeric',
             minute: 'numeric'

--- a/src/app/services/utils.service.spec.ts
+++ b/src/app/services/utils.service.spec.ts
@@ -257,7 +257,7 @@ describe('UtilsService', () => {
 
     it('should standardize date format', () => {
       const result = service.timeFormatter(NOW);
-      const formatted = new Intl.DateTimeFormat('en-GB', {
+      const formatted = new Intl.DateTimeFormat('en-US', {
         hour12: true,
         hour: 'numeric',
         minute: 'numeric'
@@ -268,7 +268,7 @@ describe('UtilsService', () => {
     it('should standardize date format international format', () => {
       const onePMUTC = `${moment().format('YYYY-MM-DD')} 13:00:00.000Z`;
       const result = service.timeFormatter(onePMUTC); // follows local GMT
-      const formatted = new Intl.DateTimeFormat('en-GB', {
+      const formatted = new Intl.DateTimeFormat('en-US', {
         hour12: true,
         hour: 'numeric',
         minute: 'numeric'
@@ -279,7 +279,7 @@ describe('UtilsService', () => {
     it('should ensure all numeric time format is return in expected time format (h:mm a)', () => {
       LOCAL_TIME_TODAY.forEach(timeString => {
         const result = service.timeFormatter(timeString);
-        const formatted = new Intl.DateTimeFormat('en-GB', {
+        const formatted = new Intl.DateTimeFormat('en-US', {
           hour12: true,
           hour: 'numeric',
           minute: 'numeric'

--- a/src/app/services/utils.service.ts
+++ b/src/app/services/utils.service.ts
@@ -210,13 +210,13 @@ export class UtilsService {
       return 'Tomorrow';
     }
     if (date.isSame(compareDate, 'd')) {
-      return new Intl.DateTimeFormat('en-GB', {
+      return new Intl.DateTimeFormat('en-US', {
         hour12: true,
         hour: 'numeric',
         minute: 'numeric'
       }).format(date.toDate());
     }
-    return new Intl.DateTimeFormat('en-GB', {
+    return new Intl.DateTimeFormat('en-US', {
       month: 'short',
       day: 'numeric'
     }).format(date.toDate());
@@ -232,7 +232,7 @@ export class UtilsService {
       return '';
     }
     const date = new Date(this.iso8601Formatter(time));
-    const formattedTime = new Intl.DateTimeFormat('en-GB', {
+    const formattedTime = new Intl.DateTimeFormat('en-US', {
       hour12: true,
       hour: 'numeric',
       minute: 'numeric'
@@ -270,7 +270,7 @@ export class UtilsService {
       return 'Today';
     }
 
-    return new Intl.DateTimeFormat('en-GB', {
+    return new Intl.DateTimeFormat('en-US', {
       month: 'short',
       day: 'numeric',
       year: 'numeric'

--- a/src/app/services/utils.service.ts
+++ b/src/app/services/utils.service.ts
@@ -216,7 +216,7 @@ export class UtilsService {
         minute: 'numeric'
       }).format(date.toDate());
     }
-    return new Intl.DateTimeFormat('en-US', {
+    return new Intl.DateTimeFormat('en-GB', {
       month: 'short',
       day: 'numeric'
     }).format(date.toDate());
@@ -270,7 +270,7 @@ export class UtilsService {
       return 'Today';
     }
 
-    return new Intl.DateTimeFormat('en-US', {
+    return new Intl.DateTimeFormat('en-GB', {
       month: 'short',
       day: 'numeric',
       year: 'numeric'


### PR DESCRIPTION
Jira story - https://intersective.atlassian.net/browse/AV2-705

Initially plan to create custom format using `Intl.DateTimeFormat.prototype.formatToParts()` but issue was in the `locales argument`. in `en-GB` British English format returning the 0 for 12 but `en-US` US English format returns 12. so i replace all `en-GB` with `en-US`.

**Note**
add `en-GB` for date formats. Because `en-US` gives the day and month in reverse order. So `en-US` only using for time formating.