### PR TITLE
[AV2-753] bugfix/made-backward-compatible

### DIFF
--- a/src/app/fast-feedback/fast-feedback-submitter.service.ts
+++ b/src/app/fast-feedback/fast-feedback-submitter.service.ts
@@ -12,8 +12,8 @@ export class FastFeedbackSubmitterService {
     private request: RequestService
   ) {}
 
-  submit(data, params) {
-    return this.request.post(api.submit, data, {params: params});
+  submit(data, params: {}) {
+    return this.request.post(api.submit, data, { params });
   }
 
 }

--- a/src/app/fast-feedback/fast-feedback.component.spec.ts
+++ b/src/app/fast-feedback/fast-feedback.component.spec.ts
@@ -167,6 +167,13 @@ describe('FastFeedbackComponent', () => {
         });
       }));
 
+      it('should still submit, if meta is undefined', fakeAsync(() => {
+        component.meta = undefined;
+        component.submit();
+
+        tick(2500);
+        expect(fastfeedbackSpy.submit).toHaveBeenCalled();
+      }));
     });
   });
 });

--- a/src/app/fast-feedback/fast-feedback.component.ts
+++ b/src/app/fast-feedback/fast-feedback.component.ts
@@ -59,16 +59,22 @@ export class FastFeedbackComponent implements OnInit {
         choice_id: answer,
       });
     });
-    // prepare parameters
-    const params = {
-      context_id: this.meta.context_id
-    };
-    // if team_id exist, pass team_id
-    if (this.meta.team_id) {
-      params['team_id'] = this.meta.team_id;
-    } else if (this.meta.target_user_id) {
-      // otherwise, pass target_user_id
-      params['target_user_id'] = this.meta.target_user_id;
+
+    // without meta value, fastfeedback submission would
+    // never work(made backward compatible)
+    let params = {};
+    if (this.meta !== undefined) {
+      // prepare parameters
+      params = {
+        context_id: this.meta.context_id
+      };
+      // if team_id exist, pass team_id
+      if (this.meta.team_id) {
+        params['team_id'] = this.meta.team_id;
+      } else if (this.meta.target_user_id) {
+        // otherwise, pass target_user_id
+        params['target_user_id'] = this.meta.target_user_id;
+      }
     }
 
     const nrFastFeedbackSubmissionTracer = this.newRelic.createTracer('fastfeeback submission');

--- a/src/app/fast-feedback/fast-feedback.service.ts
+++ b/src/app/fast-feedback/fast-feedback.service.ts
@@ -50,7 +50,7 @@ export class FastFeedbackService {
   fastFeedbackModal(
     props: {
       questions?: Array<Question>;
-      meta?: Meta;
+      meta?: Meta | Object;
     },
     modalOnly: boolean = false
   ): Promise<HTMLIonModalElement | void> {


### PR DESCRIPTION
this fix is part of the https://intersective.atlassian.net/browse/AV2-750 (to make hybrid alpha build work correctly)

### Context of this fix
I think there is recent changes that repeatedly trigger fast-feedback form popup in the older test program on AppV2 development environment.

The new change is also causing the new fast-feedback form modal get popup without Meta value [this Endpoint](https://sandbox.practera.com/api/v2/observation/slider/list.json), so then user can never submit fastfeedback without Meta object returned from this API.

Video clip available in [this comment link](https://intersective.atlassian.net/browse/AV2-750?focusedCommentId=45496)

If this fix is not necessary, please feel free to let me know too!