### PR TITLE
Av2 770/disable chat module

### DIFF
--- a/src/app/services/push-notification.service.ts
+++ b/src/app/services/push-notification.service.ts
@@ -26,7 +26,7 @@ export class PushNotificationService {
   ) {}
 
   async initiatePushNotification(): Promise<void> {
-    await this.requestPermission()
+    await this.requestPermission();
     await this.registerToServer();
     await this.listenToError();
     await this.listenToReceiver();

--- a/src/app/shared/request/request.service.ts
+++ b/src/app/shared/request/request.service.ts
@@ -64,6 +64,8 @@ export class RequestService {
     }
   }
 
+  internalErrorCheck = false;
+
   /**
    *
    * @param {'Content-Type': string } header
@@ -238,9 +240,16 @@ export class RequestService {
     return;
   }
 
+  public hideChatTab () {
+    return !this.internalErrorCheck;
+  }
+
   private handleError(error: HttpErrorResponse | any) {
     if (this.devMode.isDevMode()) {
       console.error(error); // log to console instead
+      if (error.status === 500 && error.url.includes('chat')) {
+        this.hideChatTab();
+      }
     }
 
     // log the user out if jwt expired

--- a/src/app/tabs/tabs.component.spec.ts
+++ b/src/app/tabs/tabs.component.spec.ts
@@ -15,6 +15,7 @@ import { TabsComponent } from './tabs.component';
 import { ModalController } from '@ionic/angular';
 import { MockRouter } from '@testing/mocked.service';
 import { Apollo } from 'apollo-angular';
+import { RequestService } from '@shared/request/request.service';
 
 describe('TabsComponent', () => {
   let component: TabsComponent;
@@ -27,6 +28,7 @@ describe('TabsComponent', () => {
   let reviewsSpy: jasmine.SpyObj<ReviewListService>;
   let eventsSpy: jasmine.SpyObj<EventListService>;
   let utils: UtilsService;
+  let requestSpy: jasmine.SpyObj<RequestService>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -77,6 +79,10 @@ describe('TabsComponent', () => {
           useValue: jasmine.createSpyObj('EventListService', ['getEvents'])
         },
         {
+          provide: RequestService,
+          useValue: jasmine.createSpyObj('RequestService', ['hideChatTab'])
+        },
+        {
           provide: Router,
           useClass: MockRouter
         },
@@ -96,12 +102,14 @@ describe('TabsComponent', () => {
     switcherSpy = TestBed.inject(SwitcherService) as jasmine.SpyObj<SwitcherService>;
     reviewsSpy = TestBed.inject(ReviewListService) as jasmine.SpyObj<ReviewListService>;
     eventsSpy = TestBed.inject(EventListService) as jasmine.SpyObj<EventListService>;
+    requestSpy = TestBed.inject(RequestService) as jasmine.SpyObj<RequestService>;
 
     switcherSpy.getTeamInfo.and.returnValue(of(''));
     reviewsSpy.getReviews.and.returnValue(of(['', '']));
     eventsSpy.getEvents.and.returnValue(of([{id: 1}]));
     tabsSpy.getNoOfChats.and.returnValue(of(4));
     tabsSpy.getNoOfTodoItems.and.returnValue(of(5));
+    requestSpy.hideChatTab.and.returnValue(of(false));
     component.routeUrl = '/test';
   });
 
@@ -127,12 +135,16 @@ describe('TabsComponent', () => {
   describe('when testing onEnter()', () => {
     it('should get correct data', () => {
       storageSpy.get.and.returnValue(0);
+      requestSpy.hideChatTab.and.returnValue(false);
       fixture.detectChanges();
       expect(component.noOfTodoItems).toBe(5);
       expect(component.noOfChats).toBe(4);
       expect(component.showChat).toBe(true);
       expect(component.showReview).toBe(true);
       expect(component.showEvents).toBe(true);
+      requestSpy.hideChatTab.and.returnValue(true);
+      fixture.detectChanges();
+      expect(component.showReview).toBe(false);
     });
 
     it('should get correct data without team id', () => {
@@ -145,6 +157,7 @@ describe('TabsComponent', () => {
       });
       reviewsSpy.getReviews.and.returnValue(of([]));
       eventsSpy.getEvents.and.returnValue(of([]));
+      requestSpy.hideChatTab.and.returnValue(of(''));
       fixture.detectChanges();
       expect(component.noOfChats).toBe(0);
       expect(component.showChat).toBe(false);

--- a/src/app/tabs/tabs.component.ts
+++ b/src/app/tabs/tabs.component.ts
@@ -9,6 +9,7 @@ import { Router } from '@angular/router';
 import { SharedService } from '@services/shared.service';
 import { EventListService } from '@app/event-list/event-list.service';
 import { NewRelicService } from '@shared/new-relic/new-relic.service';
+import { RequestService } from '@shared/request/request.service';
 
 @Component({
   selector: 'app-tabs',
@@ -34,6 +35,7 @@ export class TabsComponent extends RouterEnter {
     private sharedService: SharedService,
     private eventsService: EventListService,
     private newRelic: NewRelicService,
+    private requestService: RequestService
   ) {
     super(router);
     this.newRelic.setPageViewName('tab');
@@ -55,6 +57,7 @@ export class TabsComponent extends RouterEnter {
         this.noOfChats = noOfChats;
       });
     });
+
   }
 
   private _initialise() {
@@ -107,6 +110,7 @@ export class TabsComponent extends RouterEnter {
         this.showEvents = !this.utils.isEmpty(events);
       });
     }
+    this._hidingChatTab();
   }
 
   private _checkRoute() {
@@ -147,6 +151,13 @@ export class TabsComponent extends RouterEnter {
   private _topicStopReading() {
     // if user looking at topic mark it stop reading before go back.
     this.sharedService.markTopicStopOnNavigating();
+  }
+
+  private _hidingChatTab() {
+    const checkHideTab = this.requestService.hideChatTab();
+    if (checkHideTab) {
+      this.showChat = false;
+    }
   }
 
 }

--- a/src/app/tabs/tabs.component.ts
+++ b/src/app/tabs/tabs.component.ts
@@ -110,7 +110,7 @@ export class TabsComponent extends RouterEnter {
         this.showEvents = !this.utils.isEmpty(events);
       });
     }
-    this._hidingChatTab();
+    this.hidingChatTab();
   }
 
   private _checkRoute() {
@@ -153,7 +153,7 @@ export class TabsComponent extends RouterEnter {
     this.sharedService.markTopicStopOnNavigating();
   }
 
-  private _hidingChatTab() {
+  hidingChatTab() {
     const checkHideTab = this.requestService.hideChatTab();
     if (checkHideTab) {
       this.showChat = false;


### PR DESCRIPTION
This is a temporary workaround for issue where older program that’s not compatible with new chat endpoint (graphql).
This fix just happen on native app (even though it works in web version too), so when our native app tester use the app they won’t run into chat feature error as there is big chance tester would be using older program to test our native app.