### PR TITLE
provoide default value to production mode and skip global login

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+export CUSTOMPLAIN_SKIPGLOBALLOGINFLAG=${CUSTOMPLAIN_SKIPGLOBALLOGINFLAG:-false}
+export CUSTOMPLAIN_PRDMODEFLAG=${CUSTOMPLAIN_PRDMODEFLAG:-true}
+while IFS='=' read -r name value ; do
+    if [[ $name == 'CUSTOMPLAIN_'* ]]; then
+        sed -i "s#'<$name>'#${!name}#g" src/environments/environment.custom.ts
+        echo "replacing <$name> to ${!name}"
+    fi
+done < <(env)
 while IFS='=' read -r name value ; do
     if [[ $name == 'CUSTOM_'* ]]; then
         sed -i "s#<$name>#${!name}#g" src/environments/environment.custom.ts

--- a/src/environments/environment.custom.ts
+++ b/src/environments/environment.custom.ts
@@ -1,6 +1,6 @@
 export const environment = {
-  production: true,
-  skipGlobalLogin: false,
+  production: '<CUSTOMPLAIN_PRDMODEFLAG>',
+  skipGlobalLogin: '<CUSTOMPLAIN_SKIPGLOBALLOGINFLAG>',
   appkey: '<CUSTOM_APPKEY>',
   pusherKey: '<CUSTOM_PUSHERKEY>',
   env: '<CUSTOM_ENVIRONMENT>',


### PR DESCRIPTION
**Story/Ticket Reference ID from JIRA:**
enable that they can provide as env variables, the production flag default as true and skip global login default false. The build process does not have to put those env because the script gives them default values if the env do not exist.

**Additional Comments:**
`Add here`

**Checklist:**

- [ x ] Unit test completed?: Y
- [ x ] Docs folder up to date?: Y

All Checklist are okay.

This PR looks great - it's ready to merge! Please review and let's ship it. :)